### PR TITLE
choose font size for each line

### DIFF
--- a/include/canvas.h
+++ b/include/canvas.h
@@ -17,11 +17,11 @@ public:
     X11Canvas(Display* display, Window window, Visual* visual, int screen);
     ~X11Canvas();
 
-    void setFont(const std::string& fontname);
+    void setFont(int n, const std::string& fontname);
     void setColor(const Color& color);
     void drawRect(int x, int y, unsigned int w, unsigned int h) const;
-    void drawString(int x, int y, const std::string& text) const;
-    IntPair getStringDimension(const std::string& text) const;
+    void drawString(int x, int y, int font_n, const std::string& text) const;
+    IntPair getStringDimension(int font_n, const std::string& text) const;
 
 private:
 
@@ -30,7 +30,7 @@ private:
     Colormap colormap;
     int screen;
 
-    XftFont* xftFont;
+    XftFont* xftFonts[10];
     XftDraw* xftDraw;
     XftColor xftColor;
 

--- a/include/config.h
+++ b/include/config.h
@@ -31,8 +31,8 @@ public:
     int screenEdgeSpacing;
     int lineSpacing;
     // font
-    std::string fontName;
-    int fontSize;
+    std::string fontName[10];
+    int fontSize[10];
     // colors
     Ansi::Profile colorProfile;
     std::string tempDefaultForegroundColor;

--- a/include/gui.h
+++ b/include/gui.h
@@ -34,11 +34,11 @@ public:
     void setScreenEdgeSpacing(unsigned int spacing);
     void setLineSpacing(unsigned int spacing);
     void setMonitorIndex(unsigned int index);
-    void setFont(const std::string& font);
+    void setFont(int n, const std::string& font);
 
     void flush();
     void clearMessages();
-    void addMessage(const std::string& message);
+    void addMessage(int font_n, const std::string& message);
 
     static std::string orientationToString(Orientation orientation);
     static Orientation orientationFromString(const std::string& input);
@@ -127,13 +127,13 @@ class DrawTextCmd : public DrawCmd
 
 public:
 
-    DrawTextCmd(int x, int y, const std::string& text);
+    DrawTextCmd(int x, int y, int font_n, const std::string& text);
 
     virtual void draw(X11Canvas* canvas, int offsetX, float alpha) const;
 
 private:
 
-    int x, y;
+    int x, y, font_n;
     std::string text;
 
 };

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -44,8 +44,21 @@ void loadInputFile(const std::string& filename)
 
     std::ifstream filein(filename, std::ifstream::in);
     int i = 0;
+    int font_n=0, l_font_n;
+    char font_code[2];
+    font_code[1]=0;
     for (std::string line; std::getline(filein, line) && i < LINE_LIMIT; ++i) {
-        gui->addMessage(line);
+        font_code[0]=line[0];
+        if(isdigit(font_code[0]) and line[1]=='~') { // set font for this line and further
+            font_n=atoi(font_code);
+            line.erase(0,2);
+        }
+        l_font_n=font_n;
+        if(isdigit(font_code[0]) and line[1]=='!') { // set font just for this line
+            l_font_n=atoi(font_code);
+            line.erase(0,2);
+        }
+        gui->addMessage(l_font_n, line);
     }
     filein.close();
 }
@@ -88,7 +101,8 @@ int main(int argc, char* argv[])
     gui->setLineSpacing(config.lineSpacing);
     gui->setMonitorIndex(config.monitorIndex);
     // Font
-    gui->setFont(config.fontName + "-" + std::to_string(config.fontSize));
+    for(int i=0; i<10; i++)
+        gui->setFont(i, config.fontName[i] + "-" + std::to_string(config.fontSize[i]));
     // Colors
     gui->setColorProfile(config.colorProfile);
     gui->setDefaultForgroundColor(config.defaultForegroundColor);

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -136,10 +136,10 @@ void TestConfig::test_fromFile() {
 	TEST_CHECK(fileConfig.screenEdgeSpacing ==  10);
 	TEST_CHECK(fileConfig.lineSpacing != defaultConfig.lineSpacing);
 	TEST_CHECK(fileConfig.lineSpacing ==  20);
-	TEST_CHECK(fileConfig.fontName != defaultConfig.fontName);
-	TEST_CHECK(fileConfig.fontName == "Mx437 IBM VGA 8x16");
-	TEST_CHECK(fileConfig.fontSize != defaultConfig.fontSize);
-	TEST_CHECK(fileConfig.fontSize == 24);
+	TEST_CHECK(fileConfig.fontName[0] != defaultConfig.fontName[0]);
+	TEST_CHECK(fileConfig.fontName[0] == "Mx437 IBM VGA 8x16");
+	TEST_CHECK(fileConfig.fontSize[0] != defaultConfig.fontSize[0]);
+	TEST_CHECK(fileConfig.fontSize[0] == 24);
 	TEST_CHECK(fileConfig.colorProfile != defaultConfig.colorProfile);
 	TEST_CHECK(fileConfig.colorProfile == Ansi::Profile::XP);
 	TEST_CHECK(fileConfig.defaultForegroundColor != defaultConfig.defaultForegroundColor);


### PR DESCRIPTION
This change allows to choose font sizes from set of 10 fonts.
Configuration options changed to accept N:value syntax to change N'th font/size.
In overlay text size can be specified in beginning of line:
N! to select Nth font/size for one line
N~ to select Nth font/size for this line and further.